### PR TITLE
[simpleembed] fix exception for json

### DIFF
--- a/simpleembed/info.json
+++ b/simpleembed/info.json
@@ -1,6 +1,6 @@
 {
     "author" : ["Flame442 (Flame#2941)"],
-    "install_msg" : "Thanks for installing SimpleEmbed. Use	`[p]sendembed` to send embeds.",
+    "install_msg" : "Thanks for installing SimpleEmbed. Use `[p]sendembed` to send embeds.",
     "name" : "SimpleEmbed",
     "short" : "Simply send embeds.",
     "requirements" : [],


### PR DESCRIPTION
current json raises exception for every pull
```
json.decoder.JSONDecodeError: Invalid control character at: line 3 column 60 (char 103)
[2019-04-19 09:51:00] [ERROR] red.downloader: Invalid JSON information file at path: /home/fixator/.local/share/Red-DiscordBot/cogs/RepoManager/repos/flamecogs/simpleembed/info.json
```