### PR TITLE
[Deepfry] Allows you to deepfry avatars again

### DIFF
--- a/deepfry/deepfry.py
+++ b/deepfry/deepfry.py
@@ -197,7 +197,7 @@ class Deepfry(commands.Cog):
 			if discord.version_info.major == 1:
 				avatar = link.avatar_url_as(static_format="png")
 			else:
-				avatar = link.display_avatar
+				avatar = link.display_avatar.with_static_format("png")
 			# dpy will add a ?size= flag to the end, so for this one case we only need to check gif in
 			if ".gif" in str(avatar):
 				isgif = True

--- a/deepfry/deepfry.py
+++ b/deepfry/deepfry.py
@@ -197,7 +197,7 @@ class Deepfry(commands.Cog):
 			if discord.version_info.major == 1:
 				avatar = link.avatar_url_as(static_format="png")
 			else:
-				avatar = link.display_avatar.with_static_format("png").url
+				avatar = link.display_avatar
 			# dpy will add a ?size= flag to the end, so for this one case we only need to check gif in
 			if ".gif" in str(avatar):
 				isgif = True


### PR DESCRIPTION
## Description

Removes the URL formatting from the `display_avatar` property.

closes #72 

## Testing

First avatar is static, the second one is a gif

![image](https://github.com/Flame442/FlameCogs/assets/26130695/b09aae82-4afa-4c76-a17b-c2a14e5b9396)
