### PR TITLE
fix:Status healing berries preventing from healing-by-rest

### DIFF
--- a/pokemonduel/misc.py
+++ b/pokemonduel/misc.py
@@ -429,6 +429,9 @@ class NonVolatileEffect():
             self.current = status
             self.sleep_timer.set_turns(turns)
             msg += f"{self.pokemon.name} fell asleep{source}!\n"
+            if attacker.last_move.effect == 38:
+                    attacker.hp = attacker.starting_hp
+                    msg += f"{attacker.name}'s slumber restores its health back to full!\n"
         if status in ("poison", "b-poison"):
             if attacker is None or attacker.ability() != Ability.CORROSION:
                 if ElementType.STEEL in self.pokemon.type_ids:

--- a/pokemonduel/misc.py
+++ b/pokemonduel/misc.py
@@ -429,9 +429,9 @@ class NonVolatileEffect():
             self.current = status
             self.sleep_timer.set_turns(turns)
             msg += f"{self.pokemon.name} fell asleep{source}!\n"
-            if attacker.last_move.effect == 38:
-                    attacker.hp = attacker.starting_hp
-                    msg += f"{attacker.name}'s slumber restores its health back to full!\n"
+            if self.pokemon.last_move.effect == 38:
+                    self.pokemon.hp = self.pokemon.starting_hp
+                    msg += f"{self.pokemon.name}'s slumber restores its health back to full!\n"
         if status in ("poison", "b-poison"):
             if attacker is None or attacker.ability() != Ability.CORROSION:
                 if ElementType.STEEL in self.pokemon.type_ids:

--- a/pokemonduel/move.py
+++ b/pokemonduel/move.py
@@ -700,9 +700,6 @@ class Move():
                 msg += defender.nv.apply_status("sleep", battle, attacker=attacker, move=self)
         if self.effect == 38:
             msg += attacker.nv.apply_status("sleep", battle, attacker=attacker, move=self, turns=3, force=True)
-            if attacker.nv.sleep():
-                msg += f"{attacker.name}'s slumber restores its health back to full!\n"
-                attacker.hp = attacker.starting_hp
         if self.effect in (50, 119, 167, 200):
             msg += defender.confuse(attacker=attacker, move=self)
         # This checks if attacker.locked_move is not None as locked_move is cleared if the poke dies to rocky helmet or similar items


### PR DESCRIPTION
Previously
The eat_berry function was called before healing and healing was bounded with the condition of sleep which can be already cured by lum berry or chesto berry therefore the pokemon never gets healed

Changes
Moved the healing block of code into the apply status function itself 
healing the pokemon(move user) if the status being applied is sleep(**by self**) and the last move used is rest 
now, eat_berry function is called after healing.

the only way this could break is if the (last move stays **rest**(of the user) AND the sleep status is applied by some other behavior **by the user**) 
which is not possible as of my understanding