### PR TITLE
Add [p]topchance to WordStats

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,19 @@ Use the parameter `word` to set the word to compare.
 Use the optional parameter `amount` to change the number of members that are displayed (default `10`).  
 Use the optional parameter `min_total` to change the minimum number of words a user needs to have said to be shown.
 
+**`[p]topchance <word> [guild] [amount] [min_total]`**  
+Prints the members with the highest estimated probability that their next word would be the specified word.  
+Use the parameter `word` to set the word to compare.  
+Use the optional parameter `guild` to see the ratio in a specific guild.  
+Use the optional parameter `amount` to change the number of members that are displayed (default `10`).  
+Use the optional parameter `min_total` to change the minimum number of words a user needs to have said to be shown.
+
+**`[p]topchance global <word> [amount] [min_total]`**  
+Prints the members with the highest estimated probability that their next word would be the specified word across all guilds.  
+Use the parameter `word` to set the word to compare.  
+Use the optional parameter `amount` to change the number of members that are displayed (default `10`).  
+Use the optional parameter `min_total` to change the minimum number of words a user needs to have said to be shown.
+
 **`[p]wordstatsset <argument>`**  
 Config options for wordstats.  
 This command is only usable by the server owner and bot owner.  

--- a/wordstats/wordstats.py
+++ b/wordstats/wordstats.py
@@ -495,10 +495,10 @@ class WordStats(commands.Cog):
 		ctx: commands.GuildContext,
 		word: str,
 		amount: int,
-        min_total: int,
+		min_total: int,
 		*,
 		guild: Optional[discord.Guild],
-        raw: bool
+		raw: bool
 	):
 		if amount <= 0:
 			return await ctx.send('At least one member needs to be displayed.')
@@ -624,8 +624,8 @@ class WordStats(commands.Cog):
 	):
 		"""
 		Prints the members with the highest observed probability that their next word would be the specified word.
-		Compared to [p]topratio, this will naturally "float" users who spoke more words towards the top of the listing.
 		
+		Compared to `[p]topratio`, this will naturally "float" users who spoke more words towards the top of the listing.
 		Use the parameter "word" to set the word to compare.
 		Use the optional parameter "guild" to see the ratio in a specific guild.
 		Use the optional parameter "amount" to change the number of members that are displayed.
@@ -639,8 +639,8 @@ class WordStats(commands.Cog):
 	async def topchance_global(self, ctx, word: str, amount: int=10, min_total: int=0):
 		"""
 		Prints the members with the highest observed probability that their next word would be the specified word across all guilds.
-		Compared to [p]topratio, this will naturally "float" users who spoke more words towards the top of the listing.
 		
+		Compared to `[p]topratio`, this will naturally "float" users who spoke more words towards the top of the listing.
 		Use the parameter "word" to set the word to compare.
 		Use the optional parameter "amount" to change the number of members that are displayed.
 		Use the optional parameter "min_total" to change the minimum number of words a user needs to have said to be shown.

--- a/wordstats/wordstats.py
+++ b/wordstats/wordstats.py
@@ -636,7 +636,7 @@ class WordStats(commands.Cog):
 		min_total: int=0
 	):
 		"""
-		Prints the members with the highest observed probability that their next word would be the specified word.
+		Prints the members with the highest estimated probability that their next word would be the specified word.
 		
 		Compared to `[p]topratio`, this will naturally "float" users who spoke more words towards the top of the listing.
 		Use the parameter "word" to set the word to compare.
@@ -651,7 +651,7 @@ class WordStats(commands.Cog):
 	@topchance.command(name='global')
 	async def topchance_global(self, ctx, word: str, amount: int=10, min_total: int=0):
 		"""
-		Prints the members with the highest observed probability that their next word would be the specified word across all guilds.
+		Prints the members with the highest estimated probability that their next word would be the specified word across all guilds.
 		
 		Compared to `[p]topratio`, this will naturally "float" users who spoke more words towards the top of the listing.
 		Use the parameter "word" to set the word to compare.

--- a/wordstats/wordstats.py
+++ b/wordstats/wordstats.py
@@ -631,7 +631,7 @@ class WordStats(commands.Cog):
 			guild = ctx.guild
 		await self._topratio(ctx, word, amount, min_total, guild=guild, raw=False)
 	
-	@topratio.command(name='global')
+	@topchance.command(name='global')
 	async def topchance_global(self, ctx, word: str, amount: int=10, min_total: int=0):
 		"""
 		Prints the members with the highest observed probability that their next word would be the specified word across all guilds.

--- a/wordstats/wordstats.py
+++ b/wordstats/wordstats.py
@@ -557,6 +557,10 @@ class WordStats(commands.Cog):
 		else:
 			memberprint = f'**{n}** members'
 			have_has = 'have'
+		if raw:
+			said = 'said'
+		else:
+			said = 'the highest chance of saying'
 		if guild == ctx.guild:
 			guildprint = 'in this server'
 		elif guild is None:
@@ -569,7 +573,7 @@ class WordStats(commands.Cog):
 		try:
 			await ctx.send(
 				f'The {memberprint} {guildprint} {min_words_msg}who {have_has} '
-				f'said the word **{word}** the most compared to other words '
+				f'{said} the word **{word}** the most compared to other words '
 				f'{"is" if n == 1 else "are"}:\n```{result}```'
 			)
 		except discord.errors.HTTPException:


### PR DESCRIPTION
As per the discussion in testing in the Red server. Uses Laplace's [rule of succession](https://youtu.be/8idr1WZ1A7Q)* to bias ratios with high confidence towards the top.
*<sup>Theoretically using the [lower bound of the Wilson score confidence interval](https://www.evanmiller.org/how-not-to-sort-by-average-rating.html) would be more "proper" but that's probably overkill for a cog like wordstats.</sup>

I don't have a full wordstats database to test this on, but it does at least work with the limited test dataset that I have.